### PR TITLE
fix issue when windows username contains dots

### DIFF
--- a/setup/windows/setup.ps1
+++ b/setup/windows/setup.ps1
@@ -1,4 +1,4 @@
-$USERNAME=(Write-Output $env:username)
+$USERNAME=(Write-Output $env:username) -replace "\.", "-"
 
 $MINIKUBE_DIR=($HOME) + "\.minikube"
 $CERT_DIRECTORY="$MINIKUBE_DIR\redhat-certs"


### PR DESCRIPTION
the windows user can contain dots which are not valid for namespace creation.
for example with user name "first.last", the setup script fails with:
```
Creating namespace 'first.last-dev' ...
The Namespace "first.last-dev" is invalid: metadata.name: Invalid value: "first.last-dev": a lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')
Error while creating namespace first.last-dev.
```

the solution here is to replace every '.' with '-'