### PR TITLE
Convert mixed case usernames to all lowercase

### DIFF
--- a/setup/windows/setup.ps1
+++ b/setup/windows/setup.ps1
@@ -1,4 +1,4 @@
-$USERNAME=(Write-Output $env:username)
+$USERNAME=(Write-Output $env:username.toLower())
 
 $MINIKUBE_DIR=($HOME) + "\.minikube"
 $CERT_DIRECTORY="$MINIKUBE_DIR\redhat-certs"


### PR DESCRIPTION
My username actually uses mixed case characters (MilcoNuman), but the setup script errors out during namespace creation (which only supports lowercase letters).